### PR TITLE
fix: missing dependency pkgconfig(gtk+-3.0) needed at runtime

### DIFF
--- a/piper.spec
+++ b/piper.spec
@@ -27,6 +27,7 @@ Requires:       python3dist(pycairo)
 Requires:       python3dist(pygobject)
 Requires:       python-gobject3
 Requires:       python-gi
+Requires:       pkgconfig(gtk+-3.0)
 
 BuildArch:      noarch
 

--- a/piper.spec
+++ b/piper.spec
@@ -1,6 +1,6 @@
 Name:           piper
 Version:        0.8
-Release:        1
+Release:        2
 Summary:        GTK application to configure gaming devices
 Group:          System/Configuration
 License:        GPLv2+


### PR DESCRIPTION
Solves https://github.com/OpenMandrivaAssociation/distribution/issues/3113.
This corresponds to the package `lib64gtk+3.0-devel`.